### PR TITLE
Fix #1. Workaround for angular not cleaning up routing events when module is destroyed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,20 @@ Helpers for building [single-spa](https://github.com/CanopyTax/single-spa) appli
 An example can be found in the [single-spa-examples](https://github.com/CanopyTax/single-spa-examples/blob/master/src/angular2/angular2.app.js) repository.
 
 ## Quickstart
-
 First, in the child application, run `npm install --save single-spa-angular2` (or `jspm install npm:single-spa-angular2` if your child application is managed by jspm). Then, in your [child app's entry file](https://github.com/CanopyTax/single-spa/blob/docs-1/docs/configuring-child-applications.md#the-entry-file), do the following:
 
 ```js
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import singleSpaAngular2 from 'single-spa-angular2';
 import mainModule from './main-module.ts';
+import {Router} from '@angular/router';
 
 const ng2Lifecycles = singleSpaAngular2({
 	domElementGetter,
 	mainModule,
 	angularPlatform: platformBrowserDynamic(),
 	template: `<component-to-render />`,
+	Router,
 })
 
 export const bootstrap = [
@@ -45,3 +46,4 @@ All options are passed to single-spa-angular2 via the `opts` parameter when call
 - `mainModule`: (required) An Angular 2 module class. If you're using Typescript or ES6 decorators, this is a class with the @NgModule decorator on it.
 - `angularPlatform`: (required) The platform with which to bootstrap your module. The "Angular platform" refers to whether the code is running on the browser, mobile, server, etc. In the case of a single-spa application, you should use the `platformBrowserDynamic` platform.
 - `template`: (required) An html string that will be put into the DOM Element returned by `domElementGetter`. This template can be anything, but it is recommended that you keeping it simple by making it only one Angular component. For example, `<my-component />` is recommended, but `<div><my-component /><span>Hello</span><another-component /></div>` is allowed. Note that `innerHTML` is used to put the template onto the DOM.
+- `Router`: (optional) The angular router class. If not provided, single-spa-angular2 will assume you are not using @angular/router.

--- a/src/single-spa-angular2.js
+++ b/src/single-spa-angular2.js
@@ -56,6 +56,8 @@ function mount(opts) {
 
 function unmount(opts) {
 	return new Promise((resolve, reject) => {
+		const routerRef = opts.bootstrappedModule.injector.get(Router);
+		routerRef.dispose();
 		opts.bootstrappedModule.destroy();
 		delete opts.bootstrappedModule;
 		resolve();

--- a/src/single-spa-angular2.js
+++ b/src/single-spa-angular2.js
@@ -4,6 +4,8 @@ const defaultOpts = {
 	angularPlatform: null,
 	mainModule: null,
 	template: null,
+	// optional opts
+	Router: null,
 };
 
 export default function singleSpaAngular2(userOpts) {
@@ -56,8 +58,10 @@ function mount(opts) {
 
 function unmount(opts) {
 	return new Promise((resolve, reject) => {
-		const routerRef = opts.bootstrappedModule.injector.get(Router);
-		routerRef.dispose();
+		if (opts.Router) {
+			const routerRef = opts.bootstrappedModule.injector.get(opts.Router);
+			routerRef.dispose();
+		}
 		opts.bootstrappedModule.destroy();
 		delete opts.bootstrappedModule;
 		resolve();


### PR DESCRIPTION
See #1, https://github.com/CanopyTax/single-spa/issues/115, https://github.com/angular/angular/issues/19079, and http://plnkr.co/edit/43a4sWEsdm5yfpVkJ5Zs?p=preview