### PR TITLE
The lifecycle method 'mount' does receive the module instance now

### DIFF
--- a/src/single-spa-angular2.js
+++ b/src/single-spa-angular2.js
@@ -52,7 +52,7 @@ function mount(opts) {
 		.angularPlatform
 		.bootstrapModule(opts.mainModule)
 		.then(module => {
-			opts.bootstrappedModule = module;
+			return opts.bootstrappedModule = module;
 		})
 }
 


### PR DESCRIPTION
It would be great if we could pass the instantiated module down to the middle ware. This is especially useful since this (https://github.com/CanopyTax/single-spa/pull/156) PR has been merged. Here is a simple use case for this:

```js
// root-application.js
singleSpa.registerApplication('app1', () =>  {}, () => {}, {authToken: "d83jD63UdZ6RS6f70D0"});
```

```js
// app.js
export function mount(props) {
    return ngLifecycles.mount(props).then((module) => {
        module.instance.setAuthToken(props.customProps.authToken);
    });
}
```

```js
// main-module.ts
@NgModule({
// ...
})
export default class MainModule {
    setAuthToken(authToken) {
        // do something with the authToken
    }
}
```

Our actual use case is to pass down a reference to the communication layer which we use for inter-app-communication. So there may be many other use cases as well.

Here is the react counterpart https://github.com/CanopyTax/single-spa-react/pull/27